### PR TITLE
Fix typos in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AI编程工具指南 - Vibe Code</title>
+    <title>AI编程工具指南 - Vibe Coding</title>
     <meta name="description" content="全面的AI编程工具指南，包括Claude Code、Cursor、Vibe Coding等主流工具的详细介绍和使用技巧">
     <style>
         :root {
@@ -498,7 +498,7 @@
     <nav>
         <div class="nav-container">
             <div class="logo">
-                🎯 Vibe Code
+                🎯 Vibe Coding
             </div>
             <ul class="nav-links">
                 <li><a href="#articles">文章指南</a></li>

--- a/vibe_coding.html
+++ b/vibe_coding.html
@@ -652,7 +652,7 @@
                         <pre><code>bash -c "$(curl -fsSL https://raw.githubusercontent.com/LLM-Red-Team/kimi-cc/refs/heads/main/install.sh)"</code></pre>
 
                         <h4>第二步：跳过地区限制</h4>
-                        <p>因为 Claude 限制中国地区的实用，在终端运行以下命令可以跳过 Claude 的地区审核：</p>
+                        <p>因为 Claude 限制中国地区的使用，在终端运行以下命令可以跳过 Claude 的地区审核：</p>
 
                         <div class="code-header">
                             <span>跳过地区限制</span>
@@ -707,7 +707,7 @@ export ANTHROPIC_API_KEY=sk-xxx</code></pre>
                             <h4>📝 在 CLAUDE.md 中可以记录：</h4>
                             <ul>
                                 <li>常用 bash 命令和工具</li>
-                                <li>核心文件和实用函数路径</li>
+                                <li>核心文件和使用函数路径</li>
                                 <li>代码风格指南和规范</li>
                                 <li>测试指令和流程</li>
                                 <li>仓库规范（如分支命名规则）</li>


### PR DESCRIPTION
## Summary
- unify `Vibe Coding` wording on index page
- fix Chinese typo in vibe coding guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889e8ec775c8329b00201956b22df0d